### PR TITLE
Add: Ko-fi support link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ This extension requires the following permissions:
 - `tabs`: To access tab information and titles
 - `tabGroups`: To access tab group information
 
+## Support
+
+If you find this extension useful, consider supporting its development:
+
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/jade913)
+
 ## License
 
 MIT License


### PR DESCRIPTION
## Summary
- Add Ko-fi donation button to README for user support

## Changes
- Added Support section with Ko-fi official badge
- Links to https://ko-fi.com/jade913
- Provides easy way for users to support extension development

🤖 Generated with [Claude Code](https://claude.com/claude-code)