### PR TITLE
fix: unnamed group title fallback (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.1] - 2026-04-08
+
+### Fixed
+- Unnamed tab groups now correctly display "Group N" as fallback (was showing empty string)
+
 ## [1.2.0] - 2026-04-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firefox-tab-group-title-copier",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Firefox extension to copy all tab titles from tab groups",
   "private": true,
   "scripts": {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const groupTitle = document.createElement('span')
         groupTitle.className = 'group-title'
-        groupTitle.textContent = group.title ?? `Group ${group.id}`
+        groupTitle.textContent = group.title || `Group ${group.id}`
 
         const copyButtons = document.createElement('div')
         copyButtons.className = 'copy-buttons'

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.2",
+  "version": "1.2.1",
   "description": "__MSG_extensionDescription__",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
## Summary

Firefox returns `""` (empty string) for unnamed tab groups, not `null`/`undefined`. The `??` operator only catches nullish values, so the `"Group N"` fallback was never shown. Changed to `||`.

## Root Cause

```ts
// before: ?? doesn't catch ""
group.title ?? `Group ${group.id}`

// after: || catches "" as falsy
group.title || `Group ${group.id}`
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)