### PR TITLE
chore: bump version to v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.2] - 2026-04-08
+
+### Fixed
+- Unnamed tab groups now correctly display "Group N" as fallback
+
 ## [1.2.1] - 2026-04-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firefox-tab-group-title-copier",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Firefox extension to copy all tab titles from tab groups",
   "private": true,
   "scripts": {

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "__MSG_extensionDescription__",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
## Summary

Re-release with correct tag. v1.2.1 was tagged before the group title fallback fix was merged, so AMO received a build without the fix. This bump ensures the tag points to the correct commit.

## Fix included
- Unnamed tab groups correctly display "Group N" as fallback (`||` instead of `??`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)