### PR TITLE
docs: add AMO store listing (EN/ZH/JA)

### DIFF
--- a/amo-listing.md
+++ b/amo-listing.md
@@ -1,0 +1,65 @@
+# AMO Store Listing
+
+用于填写 addons.mozilla.org 开发者后台的商店页面内容。
+
+---
+
+## Summary（概述，250字以内）
+
+### English (US)
+
+Display all your Firefox tab groups in a popup, and copy tab titles to clipboard in one click — as plain text or JSON. Click any tab to jump to it instantly.
+
+### 中文 (zh-CN)
+
+在弹出窗口中显示所有 Firefox 标签页组，一键将标签页标题复制到剪贴板（纯文本或 JSON 格式）。点击任意标签页可立即跳转聚焦。
+
+### 日本語 (ja)
+
+Firefoxのタブグループをポップアップで一覧表示し、タブのタイトルをワンクリックでクリップボードにコピー（テキストまたはJSON形式）。タブをクリックするとそのタブに即座にジャンプできます。
+
+---
+
+## Description（描述，支持部分 Markdown）
+
+### English (US)
+
+A lightweight Firefox extension for power users who work with tab groups.
+
+**Features**
+
+- Lists all tab groups across all open windows
+- Click a group to expand and see its tabs
+- **Copy as text**: copies all tab titles, one per line
+- **Copy as JSON**: copies titles and URLs as a JSON array
+- Click any tab in the list to jump to it instantly (expands collapsed groups automatically)
+- Supports private windows
+- Auto-detects browser language (English / 中文 / 日本語)
+
+### 中文 (zh-CN)
+
+专为使用标签页组的 Firefox 用户设计的轻量扩展。
+
+**功能**
+
+- 列出所有窗口中的全部标签页组
+- 点击组名展开，查看组内标签页
+- **文本复制**：将所有标签页标题逐行复制到剪贴板
+- **JSON 复制**：将标题和网址以 JSON 数组格式复制
+- 点击列表中的任意标签页，可立即跳转聚焦（折叠的组会自动展开）
+- 支持隐私窗口
+- 自动检测浏览器语言（English / 中文 / 日本語）
+
+### 日本語 (ja)
+
+タブグループを活用するFirefoxユーザーのための軽量拡張機能です。
+
+**機能**
+
+- 開いているすべてのウィンドウのタブグループを一覧表示
+- グループをクリックして展開し、タブを確認
+- **テキストコピー**：すべてのタブタイトルを1行ずつクリップボードにコピー
+- **JSONコピー**：タイトルとURLをJSON配列形式でコピー
+- リスト内のタブをクリックすると即座にジャンプ（折りたたまれたグループは自動で展開）
+- プライベートウィンドウに対応
+- ブラウザの言語を自動検出（English / 中文 / 日本語）


### PR DESCRIPTION
Add `amo-listing.md` with summary and description in English, Chinese, and Japanese for the AMO developer dashboard.